### PR TITLE
query dsl reader 처리

### DIFF
--- a/SpringBatch/build.gradle
+++ b/SpringBatch/build.gradle
@@ -4,6 +4,8 @@ plugins {
 	id 'java'
 	// 도커 연결 처리
 	id 'com.google.cloud.tools.jib' version '3.1.2'
+
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.project'
@@ -41,11 +43,30 @@ dependencies {
 	implementation group: 'com.oracle.ojdbc', name: 'ojdbc8', version: '19.3.0.0'
 	implementation group: 'com.oracle.ojdbc', name: 'orai18n', version: '19.3.0.0'
 
+	implementation 'com.querydsl:querydsl-jpa'
+
+
 	// https://mvnrepository.com/artifact/com.h2database/h2
 	testImplementation group: 'com.h2database', name: 'h2', version: '1.3.148'
 
 
 }
+
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+//querydsl 추가 끝
 
 /*test {
 	useJUnitPlatform()

--- a/SpringBatch/src/main/java/com/project/batch/config/InitDb.java
+++ b/SpringBatch/src/main/java/com/project/batch/config/InitDb.java
@@ -1,7 +1,7 @@
 package com.project.batch.config;
 
 import com.project.batch.domain.AutoQueue;
-import com.project.batch.repository.AutoQueRepository;
+import com.project.batch.repository.AutoQueueRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +13,7 @@ import javax.persistence.EntityManager;
 @RequiredArgsConstructor
 public class InitDb {
 
-    private final AutoQueRepository autoQueRepository;
+    private final AutoQueueRepository autoQueueRepository;
 
     private final InitService initService;
 

--- a/SpringBatch/src/main/java/com/project/batch/repository/AutoQueueRepository.java
+++ b/SpringBatch/src/main/java/com/project/batch/repository/AutoQueueRepository.java
@@ -1,18 +1,16 @@
 package com.project.batch.repository;
 
-import java.util.List;
-
-import javax.transaction.Transactional;
-
+import com.project.batch.domain.AutoQueue;
+import com.project.batch.model.AutoQueSchdDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.project.batch.domain.AutoQueue;
-import com.project.batch.model.AutoQueSchdDto;
+import javax.transaction.Transactional;
+import java.util.List;
 
-public interface AutoQueRepository extends JpaRepository<AutoQueue, Long>{
+public interface AutoQueueRepository extends JpaRepository<AutoQueue, Long>, AutoQueueRepositoryCustom{
 	
 	@Transactional
 	@Modifying(clearAutomatically = true)

--- a/SpringBatch/src/main/java/com/project/batch/repository/AutoQueueRepositoryCustom.java
+++ b/SpringBatch/src/main/java/com/project/batch/repository/AutoQueueRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.project.batch.repository;
+
+import com.project.batch.domain.AutoQueue;
+import com.querydsl.jpa.impl.JPAQuery;
+
+public interface AutoQueueRepositoryCustom {
+
+    JPAQuery<AutoQueue> getAutoQueue(Long minSeq, Long maxSeq, String pollKey, String serverId);
+
+}

--- a/SpringBatch/src/main/java/com/project/batch/repository/AutoQueueRepositoryImpl.java
+++ b/SpringBatch/src/main/java/com/project/batch/repository/AutoQueueRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.project.batch.repository;
+
+import com.project.batch.domain.AutoQueue;
+import com.project.batch.domain.QAutoQueue;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+@Transactional
+public class AutoQueueRepositoryImpl implements AutoQueueRepositoryCustom{
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public AutoQueueRepositoryImpl(EntityManager em){
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public JPAQuery<AutoQueue> getAutoQueue(Long minSeq, Long maxSeq, String pollKey, String serverId) {
+        return queryFactory.select(QAutoQueue.autoQueue)
+                .from(QAutoQueue.autoQueue);
+    }
+}

--- a/SpringBatch/src/main/java/com/project/batch/sender/QuerydslPagingItemReader.java
+++ b/SpringBatch/src/main/java/com/project/batch/sender/QuerydslPagingItemReader.java
@@ -1,0 +1,89 @@
+package com.project.batch.sender;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.batch.item.database.AbstractPagingItemReader;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.util.CollectionUtils;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class QuerydslPagingItemReader<T> extends AbstractPagingItemReader<T> {
+
+    protected Map<String, Object> jpaPropertyMap = new HashMap<>();
+    protected EntityManagerFactory emf;
+    protected EntityManager em;
+    protected JPAQuery<T> queryFunction;
+    protected boolean transacted = true;
+
+    public QuerydslPagingItemReader(
+            EntityManagerFactory emf,
+            int pageSize,
+            JPAQuery<T> queryFunction
+    ){
+        this();
+        this.emf = emf;
+        this.queryFunction = queryFunction;
+        setPageSize(pageSize);
+    }
+
+    public QuerydslPagingItemReader() {
+
+    }
+
+    @Override
+    protected void doOpen() throws Exception{
+        super.doOpen();
+
+        em = emf.createEntityManager(jpaPropertyMap);
+        if(em == null){
+            throw new DataAccessResourceFailureException("Unable to obtain an EntityManager");
+        }
+    }
+
+    @Override
+    protected void doReadPage() {
+        JPAQuery<T> query = createQuery()
+                .offset(0)
+                .limit(getPageSize());
+
+        initResults();
+
+        fetchQuery(query);
+    }
+
+    @Override
+    protected void doJumpToPage(int i) {
+
+    }
+
+    protected JPAQuery<T> createQuery() {
+        //JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+        return queryFunction;
+    }
+
+    protected void initResults() {
+        if (CollectionUtils.isEmpty(results)) {
+            results = new CopyOnWriteArrayList<>();
+        } else {
+            results.clear();
+        }
+    }
+
+    protected void fetchQuery(JPAQuery<T> query) {
+        if (!transacted) {
+            List<T> queryResult = query.fetch();
+            for (T entity : queryResult) {
+                em.detach(entity);
+                results.add(entity);
+            }
+        } else {
+            results.addAll(query.fetch());
+        }
+    }
+
+}

--- a/SpringBatch/src/main/java/com/project/batch/sender/auto/config/AutoQueItemWriter.java
+++ b/SpringBatch/src/main/java/com/project/batch/sender/auto/config/AutoQueItemWriter.java
@@ -1,54 +1,37 @@
 package com.project.batch.sender.auto.config;
 
-import java.util.List;
-
-import com.project.batch.repository.AutoQueRepository;
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.StepExecution;
+import com.project.batch.domain.AutoQueue;
+import com.project.batch.repository.AutoQueueRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
-import com.project.batch.model.AutoQueDto;
-import com.project.batch.sender.DefaultQueWriter;
-
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
 @Slf4j
 @StepScope
 @Component
-public class AutoQueItemWriter extends DefaultQueWriter<AutoQueDto>{
+public class AutoQueItemWriter implements ItemWriter<AutoQueue> {
 
-	private final AutoQueRepository autoQueRepository;
+	private final AutoQueueRepository autoQueueRepository;
 
-	public AutoQueItemWriter(AutoQueRepository autoQueRepository) {
-		this.autoQueRepository = autoQueRepository;
+	public AutoQueItemWriter(AutoQueueRepository autoQueueRepository) {
+		this.autoQueueRepository = autoQueueRepository;
 	}
 
 	@Override
-	public void write(List<? extends AutoQueDto> items) throws Exception {
+	public void write(List<? extends AutoQueue> items) throws Exception {
 		// TODO Auto-generated method stub
 
 		log.info("사이즈 체크" + items.size());
 
-		for(AutoQueDto autoQueDto : items){
+		for(AutoQueue autoQueDto : items){
 			log.info("테스트"+autoQueDto.toString());
-			autoQueRepository.updateAutoQueue(autoQueDto.getPollKey(), autoQueDto.getQueueId());
+			autoQueueRepository.updateAutoQueue(autoQueDto.getPollKey(), autoQueDto.getQueueId());
 		}
 
 		log.info("check Writer");
 		
 	}
-
-	@Override
-	public void beforeStep(StepExecution stepExecution) {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	public ExitStatus afterStep(StepExecution stepExecution) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
 }

--- a/SpringBatch/src/main/java/com/project/batch/sender/auto/config/AutoQueProcessor.java
+++ b/SpringBatch/src/main/java/com/project/batch/sender/auto/config/AutoQueProcessor.java
@@ -1,38 +1,23 @@
 package com.project.batch.sender.auto.config;
 
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.StepExecution;
+import com.project.batch.domain.AutoQueue;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
-import com.project.batch.model.AutoQueDto;
-import com.project.batch.sender.DefaultQueProcessor;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @StepScope
 @Component
-public class AutoQueProcessor extends DefaultQueProcessor<AutoQueDto>{
+public class AutoQueProcessor implements ItemProcessor<AutoQueue, AutoQueue> {
 	
 	@Override
-	public AutoQueDto process(AutoQueDto item) throws Exception {
+	public AutoQueue process(AutoQueue item) throws Exception {
 		// TODO Auto-generated method stub
 		Thread.sleep(100);
 		log.info("Check Process"+item.toString());
 		return item;
-	}
-
-	@Override
-	public void beforeStep(StepExecution stepExecution) {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	public ExitStatus afterStep(StepExecution stepExecution) {
-		// TODO Auto-generated method stub
-		return null;
 	}
 
 }

--- a/SpringBatch/src/main/java/com/project/batch/sender/auto/scheduler/service/AbstractAutoService.java
+++ b/SpringBatch/src/main/java/com/project/batch/sender/auto/scheduler/service/AbstractAutoService.java
@@ -1,28 +1,24 @@
 package com.project.batch.sender.auto.scheduler.service;
 
+import com.project.batch.model.AutoQueSchdDto;
+import com.project.batch.repository.AutoQueueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-import com.project.batch.domain.TemplateInfo;
-import com.project.batch.model.AutoQueSchdDto;
-import com.project.batch.repository.AutoQueRepository;
-import com.project.batch.repository.TemplateMsgInfoRepository;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AbstractAutoService implements ChnScheduleService<AutoQueSchdDto>{
 	
-	private final AutoQueRepository autoQueRepository;
+	private final AutoQueueRepository autoQueueRepository;
 
 	private Map<String, Boolean> scheduleHashMap = new ConcurrentHashMap<>();
 	
@@ -35,7 +31,7 @@ public class AbstractAutoService implements ChnScheduleService<AutoQueSchdDto>{
 	   	 String nowDateStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern(dateTimeFormat));
 	     String twoHourAgoDateStr = LocalDateTime.now().minusDays(maxMsgExpiredDays)
 	         .format(DateTimeFormatter.ofPattern(dateTimeFormat));
-	     return autoQueRepository.updatePreAutoQueue(pollKey, templateMsgId);
+	     return autoQueueRepository.updatePreAutoQueue(pollKey, templateMsgId);
 	}
 
 	@Override
@@ -44,13 +40,13 @@ public class AbstractAutoService implements ChnScheduleService<AutoQueSchdDto>{
 	}
 
 	public List<AutoQueSchdDto> getScheduleList(String pollKey){
-		return autoQueRepository.findBySchdByPollKey(pollKey);
+		return autoQueueRepository.findBySchdByPollKey(pollKey);
 	}
 
 	@Override
 	public List<String> getTemplateMsgId() {
 		// TODO Auto-generated method stub
-		return autoQueRepository.findlist();
+		return autoQueueRepository.findlist();
 	}
 
 	@Override


### PR DESCRIPTION
reader 방식 querydsl 적용